### PR TITLE
Fix Symfony\Component\Config\Definition\Builder\TreeBuilder::root() m…

### DIFF
--- a/Controller/JobController.php
+++ b/Controller/JobController.php
@@ -7,18 +7,19 @@ use Doctrine\ORM\EntityManager;
 use JMS\JobQueueBundle\Entity\Job;
 use JMS\JobQueueBundle\Entity\Repository\JobManager;
 use JMS\JobQueueBundle\View\JobFilter;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Annotation\Route;
 
-class JobController extends Controller
+class JobController extends AbstractController
 {
     /**
      * @Route("/", name = "jms_jobs_overview")
      */
-    public function overviewAction(Request $request)
+    public function overviewAction(Request $request): Response
     {
         $jobFilter = JobFilter::fromRequest($request);
 
@@ -67,7 +68,7 @@ class JobController extends Controller
     /**
      * @Route("/{id}", name = "jms_jobs_details")
      */
-    public function detailsAction(Job $job)
+    public function detailsAction(Job $job): Response
     {
         $relatedEntities = array();
         foreach ($job->getRelatedEntities() as $entity) {
@@ -128,7 +129,7 @@ class JobController extends Controller
     /**
      * @Route("/{id}/retry", name = "jms_jobs_retry_job")
      */
-    public function retryJobAction(Job $job)
+    public function retryJobAction(Job $job): RedirectResponse
     {
         $state = $job->getState();
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -35,7 +35,13 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('jms_job_queue');
-        $rootNode = $treeBuilder->getRootNode();
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('jms_job_queue');
+        }
 
         $rootNode
             ->children()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -32,10 +32,10 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('jms_job_queue');
+        $treeBuilder = new TreeBuilder('jms_job_queue');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()


### PR DESCRIPTION
…ethod called for the jms_job_queue configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.